### PR TITLE
Correção gerador aleatório de TxID

### DIFF
--- a/funcoes.php
+++ b/funcoes.php
@@ -18,7 +18,7 @@ function getTxID($tipo)
   $quantidade = ($tipo === "dinamico") ? 35 : 25;
 
   for (
-    $s = '', $i = 0, $z = strlen($a = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz 0123456789') - 1;
+    $s = '', $i = 0, $z = strlen($a = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789') - 1;
     $i != $quantidade;
     $x = rand(0, $z), $s .= $a{
       $x}, $i++


### PR DESCRIPTION
O espaço na string não é compatível com o Regex exigido.